### PR TITLE
Update python dependency - Babel 2.9.0 to 2.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # core dependencies
-    "Babel~=2.9.0",
+    "Babel~=2.12.1",
     "Click~=7.1.2",
     "filelock~=3.8.0",
     "GitPython~=3.1.30",


### PR DESCRIPTION
Frappe-bench get-untranslated was not usable. 
![image](https://user-images.githubusercontent.com/100179677/222890224-267c96f6-d48d-4e17-ae79-302204bf92ee.png)
After updated Babel to 2.12.1
![image](https://user-images.githubusercontent.com/100179677/222890477-84242993-244d-45fe-a3b6-5200b83de5ef.png)

Babel was charged from using eval to ast instead. 