### PR TITLE
Upgrade python dependency - Babel 2.9.0 to 2.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # core dependencies
-    "Babel~=2.9.0",
+    "Babel~=2.12.1",
     "Click~=8.1.3",
     "filelock~=3.8.0",
     "GitPython~=3.1.30",


### PR DESCRIPTION
`bench get-untranslated` is not working.
![pr1](https://user-images.githubusercontent.com/100179677/222895852-7fbc4923-821d-449e-b9e7-4a2bfa835d37.png)

After upgrade Babel to 2.12.1
![pr2](https://user-images.githubusercontent.com/100179677/222895865-0f10bbcc-f93c-41af-8a40-f6efd2f5f4f7.png)
